### PR TITLE
feat: enable importing torque specs between motorcycles

### DIFF
--- a/app/components/torque-import-dialog.tsx
+++ b/app/components/torque-import-dialog.tsx
@@ -1,0 +1,329 @@
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { useFetcher } from "react-router";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "~/components/ui/dialog";
+import { Button } from "~/components/ui/button";
+import { Label } from "~/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
+import { ScrollArea } from "~/components/ui/scroll-area";
+import { Checkbox } from "~/components/ui/checkbox";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import type { TorqueSpecification } from "~/db/schema";
+import type { TorqueImportCandidate } from "~/types/torque";
+
+interface TorqueImportDialogProps {
+  motorcycleId: number;
+  existingSpecs: TorqueSpecification[];
+  candidates: TorqueImportCandidate[];
+  children: ReactNode;
+}
+
+type FetcherResult =
+  | {
+      success: true;
+      intent: "torque-import";
+      imported: number;
+      overwritten: number;
+    }
+  | {
+      success: false;
+      message?: string;
+    };
+
+const normalizeName = (value: string) => value.trim().toLowerCase();
+
+const formatMotorcycleLabel = (candidate: TorqueImportCandidate) => {
+  const parts = [candidate.make, candidate.model];
+  if (candidate.modelYear) {
+    parts.push(`(${candidate.modelYear})`);
+  }
+  if (candidate.numberPlate) {
+    parts.push(`• ${candidate.numberPlate}`);
+  }
+  return parts.join(" ");
+};
+
+const formatTorqueValue = (spec: TorqueSpecification) => {
+  const formatNumber = (value: number) =>
+    value.toLocaleString("de-CH", {
+      maximumFractionDigits: 2,
+    });
+
+  const base = formatNumber(spec.torque);
+  if (spec.torqueEnd != null) {
+    return `${base} - ${formatNumber(spec.torqueEnd)}`;
+  }
+  if (spec.variation != null && Math.abs(spec.variation) > 0) {
+    return `${base} ± ${formatNumber(spec.variation)}`;
+  }
+  return base;
+};
+
+export default function TorqueImportDialog({
+  motorcycleId,
+  existingSpecs,
+  candidates,
+  children,
+}: TorqueImportDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [selectedMotorcycleId, setSelectedMotorcycleId] = useState<string>("");
+  const [selectedSpecIds, setSelectedSpecIds] = useState<number[]>([]);
+  const fetcher = useFetcher<FetcherResult>();
+  const isSubmitting = fetcher.state !== "idle";
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const existingNames = useMemo(() => {
+    const set = new Set<string>();
+    existingSpecs.forEach((spec) =>
+      set.add(normalizeName(spec.name ?? "")),
+    );
+    return set;
+  }, [existingSpecs]);
+
+  const currentCandidate = useMemo(() => {
+    if (!selectedMotorcycleId) return null;
+    const id = Number.parseInt(selectedMotorcycleId, 10);
+    return candidates.find((candidate) => candidate.id === id) ?? null;
+  }, [selectedMotorcycleId, candidates]);
+
+  const groupedSpecs = useMemo(() => {
+    if (!currentCandidate) return [];
+    const groups = new Map<string, TorqueSpecification[]>();
+    currentCandidate.torqueSpecifications.forEach((spec) => {
+      const key = spec.category || "Weitere";
+      const list = groups.get(key) ?? [];
+      list.push(spec);
+      groups.set(key, list);
+    });
+
+    return Array.from(groups.entries()).map(([category, specs]) => ({
+      category,
+      specs: specs.sort((a, b) => a.name.localeCompare(b.name, "de-CH")),
+    }));
+  }, [currentCandidate]);
+
+  useEffect(() => {
+    if (open && candidates.length > 0 && !selectedMotorcycleId) {
+      setSelectedMotorcycleId(String(candidates[0]!.id));
+    }
+  }, [open, candidates, selectedMotorcycleId]);
+
+  useEffect(() => {
+    if (!open) {
+      setSelectedMotorcycleId("");
+      setSelectedSpecIds([]);
+      setErrorMessage(null);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    setSelectedSpecIds([]);
+  }, [selectedMotorcycleId]);
+
+  useEffect(() => {
+    if (
+      open &&
+      fetcher.state === "idle" &&
+      fetcher.data &&
+      fetcher.data.success
+    ) {
+      setOpen(false);
+    }
+  }, [open, fetcher.state, fetcher.data]);
+
+  useEffect(() => {
+    if (fetcher.state !== "idle") return;
+    if (!fetcher.data) return;
+    if (fetcher.data.success) {
+      setErrorMessage(null);
+      return;
+    }
+    setErrorMessage(
+      fetcher.data.message ?? "Import konnte nicht ausgeführt werden.",
+    );
+  }, [fetcher.state, fetcher.data]);
+
+  const handleToggleSpec = (specId: number, checked: boolean) => {
+    setSelectedSpecIds((prev) => {
+      if (checked) {
+        return prev.includes(specId) ? prev : [...prev, specId];
+      }
+      return prev.filter((id) => id !== specId);
+    });
+  };
+
+  const handleSubmit = () => {
+    if (!currentCandidate || selectedSpecIds.length === 0) return;
+    const formData = new FormData();
+    formData.set("intent", "torque-import");
+    formData.set("sourceMotorcycleId", String(currentCandidate.id));
+    formData.set("motorcycleId", String(motorcycleId));
+    selectedSpecIds.forEach((id) => formData.append("torqueIds", String(id)));
+    fetcher.submit(formData, { method: "post" });
+  };
+
+  const noCandidates = candidates.length === 0;
+  const noSpecsAvailable =
+    currentCandidate != null &&
+    currentCandidate.torqueSpecifications.length === 0;
+  const submitDisabled =
+    !currentCandidate || selectedSpecIds.length === 0 || isSubmitting;
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="flex h-[600px] max-h-[90vh] w-full max-w-3xl flex-col">
+        <DialogHeader>
+          <DialogTitle>Drehmomentwerte importieren</DialogTitle>
+          <DialogDescription>
+            Übernimm vorhandene Drehmomentwerte eines anderen Motorrads in diese
+            Karte.
+          </DialogDescription>
+        </DialogHeader>
+
+        {noCandidates ? (
+          <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+            Es stehen keine weiteren Motorräder für den Import zur Verfügung.
+          </div>
+        ) : (
+          <div className="flex flex-1 flex-col gap-4 overflow-hidden">
+            <div className="space-y-2">
+              <Label htmlFor="torque-import-motorcycle">
+                Quelle auswählen
+              </Label>
+              <Select
+                value={selectedMotorcycleId}
+                onValueChange={setSelectedMotorcycleId}
+              >
+                <SelectTrigger id="torque-import-motorcycle">
+                  <SelectValue placeholder="Motorrad auswählen" />
+                </SelectTrigger>
+                <SelectContent>
+                  {candidates.map((candidate) => (
+                    <SelectItem
+                      key={candidate.id}
+                      value={String(candidate.id)}
+                    >
+                      {formatMotorcycleLabel(candidate)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {noSpecsAvailable ? (
+              <div className="flex flex-1 items-center justify-center rounded-md border border-dashed border-muted-foreground/40 px-3 py-8 text-sm text-muted-foreground">
+                Für dieses Motorrad sind keine Drehmomentwerte hinterlegt.
+              </div>
+            ) : (
+              <ScrollArea className="flex-1 rounded-md border border-border">
+                <div className="space-y-4 p-4">
+                  {groupedSpecs.map(({ category, specs }) => (
+                    <div key={category} className="space-y-2">
+                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                        {category}
+                      </p>
+                      <div className="space-y-2">
+                        {specs.map((spec) => {
+                          const checked = selectedSpecIds.includes(spec.id);
+                          const duplicate = existingNames.has(
+                            normalizeName(spec.name ?? ""),
+                          );
+
+                          return (
+                            <label
+                              key={spec.id}
+                              className="flex items-start gap-3 rounded-md border border-border bg-muted/40 px-3 py-2"
+                            >
+                              <Checkbox
+                                checked={checked}
+                                onCheckedChange={(value) =>
+                                  handleToggleSpec(
+                                    spec.id,
+                                    value === true,
+                                  )
+                                }
+                                className="mt-1"
+                              />
+                              <div className="flex-1 space-y-1">
+                                <div className="flex flex-wrap items-center justify-between gap-2">
+                                  <span className="font-medium text-foreground">
+                                    {spec.name}
+                                  </span>
+                                  <span className="text-sm font-semibold text-foreground">
+                                    {formatTorqueValue(spec)}{" "}
+                                    <span className="text-xs uppercase text-muted-foreground">
+                                      nm
+                                    </span>
+                                  </span>
+                                </div>
+                                {spec.description && (
+                                  <p className="text-xs text-muted-foreground">
+                                    {spec.description}
+                                  </p>
+                                )}
+                                {duplicate && (
+                                  <p className="flex items-center gap-2 text-xs font-medium text-amber-600">
+                                    <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                                    Bereits vorhanden – wird überschrieben.
+                                  </p>
+                                )}
+                              </div>
+                            </label>
+                          );
+                        })}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </ScrollArea>
+            )}
+          </div>
+        )}
+
+        {errorMessage && (
+          <p className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+            {errorMessage}
+          </p>
+        )}
+
+        <DialogFooter className="gap-2 sm:justify-between">
+          <Button
+            type="button"
+            variant="ghost"
+            onClick={() => setOpen(false)}
+            disabled={isSubmitting}
+          >
+            Abbrechen
+          </Button>
+          <Button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitDisabled}
+          >
+            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Ausgewählte Werte importieren
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/components/torque-specifications-panel.tsx
+++ b/app/components/torque-specifications-panel.tsx
@@ -1,10 +1,12 @@
 import { useMemo } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "~/components/ui/card";
 import { Button } from "~/components/ui/button";
-import { PlusCircle } from "lucide-react";
+import { Download, PlusCircle } from "lucide-react";
 import TorqueSpecDialog from "~/components/torque-spec-dialog";
+import TorqueImportDialog from "~/components/torque-import-dialog";
 import type { TorqueSpecification } from "~/db/schema";
 import { cn } from "~/utils/tw";
+import type { TorqueImportCandidate } from "~/types/torque";
 
 interface TorqueSpecificationsPanelProps {
   motorcycleId: number;
@@ -12,6 +14,7 @@ interface TorqueSpecificationsPanelProps {
   className?: string;
   hideInteractions?: boolean;
   title?: string;
+  importCandidates?: TorqueImportCandidate[];
 }
 
 function formatTorqueValue(spec: TorqueSpecification) {
@@ -52,6 +55,7 @@ export default function TorqueSpecificationsPanel({
   className,
   hideInteractions = false,
   title = "Drehmomentwerte",
+  importCandidates = [],
 }: TorqueSpecificationsPanelProps) {
   const grouped = useMemo(() => groupTorqueSpecifications(specs), [specs]);
 
@@ -68,12 +72,24 @@ export default function TorqueSpecificationsPanel({
             {title}
           </CardTitle>
           {!hideInteractions && (
-            <TorqueSpecDialog motorcycleId={motorcycleId}>
-              <Button variant="outline" className="print:hidden">
-                <PlusCircle className="h-4 w-4" />
-                Eintrag hinzufügen
-              </Button>
-            </TorqueSpecDialog>
+            <div className="flex flex-wrap gap-2">
+              <TorqueImportDialog
+                motorcycleId={motorcycleId}
+                existingSpecs={specs}
+                candidates={importCandidates}
+              >
+                <Button variant="outline" className="print:hidden">
+                  <Download className="h-4 w-4" />
+                  Werte importieren
+                </Button>
+              </TorqueImportDialog>
+              <TorqueSpecDialog motorcycleId={motorcycleId}>
+                <Button variant="outline" className="print:hidden">
+                  <PlusCircle className="h-4 w-4" />
+                  Eintrag hinzufügen
+                </Button>
+              </TorqueSpecDialog>
+            </div>
           )}
         </div>
       </CardHeader>

--- a/app/routes/motorcycle.torque.tsx
+++ b/app/routes/motorcycle.torque.tsx
@@ -1,10 +1,11 @@
 import { useOutletContext } from "react-router";
+import { and, eq, inArray } from "drizzle-orm";
 import TorqueSpecificationsPanel from "~/components/torque-specifications-panel";
 import type { Route } from "./+types/motorcycle.torque";
 import type { MotorcycleOutletContext } from "./motorcycle";
 
 export default function MotorcycleTorqueRoute() {
-  const { motorcycle, torqueSpecifications } =
+  const { motorcycle, torqueSpecifications, torqueImportCandidates } =
     useOutletContext<MotorcycleOutletContext>();
 
   const printMetaParts = [
@@ -34,6 +35,7 @@ export default function MotorcycleTorqueRoute() {
       <TorqueSpecificationsPanel
         motorcycleId={motorcycle.id}
         specs={torqueSpecifications}
+        importCandidates={torqueImportCandidates}
       />
     </>
   );
@@ -55,11 +57,165 @@ export async function action({ request, params }: Route.ActionArgs) {
   const context = await getMotorcycleActionContext({ request, params });
   if ("error" in context) return context.error;
 
-  const { db, respond, motorcycleId, targetMotorcycle } = context;
+  const { user, db, respond, motorcycleId, targetMotorcycle } = context;
 
   const formData = await request.formData();
   const fields = Object.fromEntries(formData);
   const intent = fields.intent as string | undefined;
+
+  if (intent === "torque-import") {
+    const sourceMotorcycleId = Number.parseInt(
+      (fields.sourceMotorcycleId as string) ?? "",
+      10,
+    );
+    const selectedIds = Array.from(
+      new Set(
+        formData
+          .getAll("torqueIds")
+          .map((value) => Number.parseInt(String(value), 10))
+          .filter((value) => Number.isSafeInteger(value) && value > 0),
+      ),
+    );
+
+    if (Number.isNaN(sourceMotorcycleId)) {
+      return respond(
+        {
+          success: false,
+          message: "Quelle konnte nicht ermittelt werden.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (sourceMotorcycleId === targetMotorcycle.id) {
+      return respond(
+        {
+          success: false,
+          message:
+            "Import aus dem gleichen Motorrad ist nicht möglich. Wähle ein anderes Motorrad aus.",
+        },
+        { status: 400 },
+      );
+    }
+
+    if (selectedIds.length === 0) {
+      return respond(
+        {
+          success: false,
+          message: "Bitte wähle mindestens einen Drehmomentwert aus.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const [{ motorcycles, torqueSpecs }] = await Promise.all([
+      import("~/db/schema"),
+    ]);
+
+    const sourceMotorcycle = await db.query.motorcycles.findFirst({
+      where: and(
+        eq(motorcycles.id, sourceMotorcycleId),
+        eq(motorcycles.userId, user.id),
+      ),
+    });
+
+    if (!sourceMotorcycle) {
+      return respond(
+        {
+          success: false,
+          message: "Ausgewähltes Motorrad wurde nicht gefunden.",
+        },
+        { status: 404 },
+      );
+    }
+
+    const sourceSpecs = await db.query.torqueSpecs.findMany({
+      where: and(
+        eq(torqueSpecs.motorcycleId, sourceMotorcycleId),
+        inArray(torqueSpecs.id, selectedIds),
+      ),
+    });
+
+    if (sourceSpecs.length !== selectedIds.length) {
+      return respond(
+        {
+          success: false,
+          message:
+            "Einige ausgewählte Drehmomentwerte konnten nicht geladen werden.",
+        },
+        { status: 400 },
+      );
+    }
+
+    const targetSpecs = await db.query.torqueSpecs.findMany({
+      where: eq(torqueSpecs.motorcycleId, targetMotorcycle.id),
+    });
+
+    const existingByName = new Map(
+      targetSpecs.map((spec) => [spec.name.trim().toLowerCase(), spec]),
+    );
+
+    let insertedCount = 0;
+    let overwrittenCount = 0;
+
+    await db.transaction(async (tx) => {
+      for (const spec of sourceSpecs) {
+        const normalized = spec.name.trim().toLowerCase();
+        const payload = {
+          motorcycleId: targetMotorcycle.id,
+          category: spec.category,
+          name: spec.name,
+          torque: spec.torque,
+          torqueEnd: spec.torqueEnd,
+          variation: spec.variation,
+          description: spec.description,
+        };
+
+        const existing = existingByName.get(normalized);
+        if (existing) {
+          await tx
+            .update(torqueSpecs)
+            .set({
+              category: payload.category,
+              name: payload.name,
+              torque: payload.torque,
+              torqueEnd: payload.torqueEnd,
+              variation: payload.variation,
+              description: payload.description,
+            })
+            .where(
+              and(
+                eq(torqueSpecs.id, existing.id),
+                eq(torqueSpecs.motorcycleId, targetMotorcycle.id),
+              ),
+            );
+          overwrittenCount += 1;
+          existingByName.set(normalized, {
+            ...existing,
+            ...payload,
+            id: existing.id,
+          });
+        } else {
+          await tx.insert(torqueSpecs).values(payload);
+          insertedCount += 1;
+          existingByName.set(normalized, {
+            ...spec,
+            ...payload,
+          });
+        }
+      }
+    });
+
+    return respond(
+      {
+        success: true,
+        intent: "torque-import",
+        imported: insertedCount + overwrittenCount,
+        overwritten: overwrittenCount,
+      },
+      { status: 200 },
+    );
+  }
 
   if (intent === "torque-add") {
     try {

--- a/app/types/torque.ts
+++ b/app/types/torque.ts
@@ -1,0 +1,10 @@
+import type { TorqueSpecification } from "~/db/schema";
+
+export type TorqueImportCandidate = {
+  id: number;
+  make: string;
+  model: string;
+  modelYear: number | null;
+  numberPlate: string | null;
+  torqueSpecifications: TorqueSpecification[];
+};


### PR DESCRIPTION
This pull request introduces a new feature that allows users to import torque specifications from other motorcycles they own, streamlining the process of reusing or updating torque values across multiple vehicles. The implementation spans backend logic for importing and overwriting specs, frontend UI for selecting source motorcycles and specs, and data loading enhancements to support candidate selection.

**Feature: Torque Specification Import**

* Backend logic for importing torque specifications:
  * Added an `action` handler to `motorcycle.torque.tsx` that processes import requests, validates source and target motorcycles, and inserts or overwrites torque specs based on name matching.
  * Ensures only specs from other motorcycles owned by the user can be imported, and prevents importing from the same motorcycle.

* Data loading and context updates:
  * Enhanced the loader in `motorcycle.tsx` to fetch all other motorcycles owned by the user and their associated torque specifications, preparing a list of import candidates. This data is now included in the outlet context. [[1]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R182-R219) [[2]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R319) [[3]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R50)
  * Updated type definitions to support the new `torqueImportCandidates` context property. [[1]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R41) [[2]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R50)

**User Interface Enhancements**

* UI component for importing torque specifications:
  * Added a new `TorqueImportDialog` component, providing a dialog to select a source motorcycle and specific torque specs to import, with duplicate detection and overwrite indication.
  * Integrated the import dialog into the `TorqueSpecificationsPanel`, including an "Import Values" button alongside the existing "Add Entry" button. [[1]](diffhunk://#diff-59e72a2c55dfa4e22eef78f15cccc565f38272999b708e5be6e417b56e61ee0cL4-R17) [[2]](diffhunk://#diff-59e72a2c55dfa4e22eef78f15cccc565f38272999b708e5be6e417b56e61ee0cR58) [[3]](diffhunk://#diff-59e72a2c55dfa4e22eef78f15cccc565f38272999b708e5be6e417b56e61ee0cR75-R92)

* Route and panel wiring:
  * Passed the import candidates from the route context to the specifications panel and dialog, ensuring only relevant motorcycles and specs are available for import. [[1]](diffhunk://#diff-c15e56d4269d6d90a3d088dafd42a9eaffa921aba8e1b2235651ff0d65614f79R2-R8) [[2]](diffhunk://#diff-c15e56d4269d6d90a3d088dafd42a9eaffa921aba8e1b2235651ff0d65614f79R38) [[3]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R580)

**Technical Improvements**

* Added necessary imports for new Drizzle ORM query features (`inArray`) and updated usages throughout the affected files. (F1a818e9L1R24)

**References:**  
[[1]](diffhunk://#diff-b5c56b8bd8dccd2c954433bd6a539684079d117283dfa9c38a8a804d844cafd5R1-R329) [[2]](diffhunk://#diff-59e72a2c55dfa4e22eef78f15cccc565f38272999b708e5be6e417b56e61ee0cL4-R17) [[3]](diffhunk://#diff-59e72a2c55dfa4e22eef78f15cccc565f38272999b708e5be6e417b56e61ee0cR58) [[4]](diffhunk://#diff-59e72a2c55dfa4e22eef78f15cccc565f38272999b708e5be6e417b56e61ee0cR75-R92) [[5]](diffhunk://#diff-c15e56d4269d6d90a3d088dafd42a9eaffa921aba8e1b2235651ff0d65614f79R2-R8) [[6]](diffhunk://#diff-c15e56d4269d6d90a3d088dafd42a9eaffa921aba8e1b2235651ff0d65614f79R38) [[7]](diffhunk://#diff-c15e56d4269d6d90a3d088dafd42a9eaffa921aba8e1b2235651ff0d65614f79L58-R219) F1a818e9L1R24, [[8]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R41) [[9]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R50) [[10]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R182-R219) [[11]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R319) [[12]](diffhunk://#diff-98c321e7c2bde6b904893b0e186bd9cfe8a840197aa9819c3fd8ab22b0199454R580)